### PR TITLE
Warning before exit

### DIFF
--- a/pages/templates/add_project.html
+++ b/pages/templates/add_project.html
@@ -8,12 +8,13 @@ Lisää projekti
 {% endblock %}
 
 {% block content %}
+
 <div class="container">
 	<div class="row justify-content-center">
 		<div class="col-8">
 			<h1 class="mt-2">Lisää projekti</h1>
 			<hr class="mt-0 mb-4">
-			<form action="" method="post">
+			<form action="" id="add_project_form" method="post">
 				{% csrf_token %}
 				<div class="row">
 					<div class="col-6">
@@ -65,5 +66,17 @@ Lisää projekti
 		</div>
 	</div>
 </div>
+
+<script type="text/javascript">
+var formChanged = false;
+var myForm = document.getElementById('add_project_form');
+myForm.addEventListener('change', () => formChanged = true);
+window.addEventListener('beforeunload', (event) => {
+  if (formChanged) {
+	  event.preventDefault();
+	  event.returnValue = '';
+  }
+});
+</script>
 
 {% endblock %}

--- a/pages/templates/add_project.html
+++ b/pages/templates/add_project.html
@@ -61,22 +61,26 @@ Lisää projekti
 					</div>
 				</div>
 				<input type="hidden" name="{{ stage_field }}" value="1" />
-				<p><input type="submit" class="btn btn-primary" value='{% trans "Esikatsele" %}' /></p>
+				<p><input type="submit" id="submit_button" class="btn btn-primary" value='{% trans "Esikatsele" %}' /></p>
 			</form>
 		</div>
 	</div>
 </div>
 
 <script type="text/javascript">
-var formChanged = false;
-var myForm = document.getElementById('add_project_form');
-myForm.addEventListener('change', () => formChanged = true);
-window.addEventListener('beforeunload', (event) => {
-  if (formChanged) {
-	  event.preventDefault();
-	  event.returnValue = '';
-  }
-});
+	document.getElementById("submit_button").addEventListener("click", function(){
+	  window.btn_clicked = true; 
+	});
+
+	var formChanged = false;
+	var myForm = document.getElementById('add_project_form');
+	myForm.addEventListener('change', () => formChanged = true);
+	window.addEventListener('beforeunload', (event) => {
+	  if (formChanged && !window.btn_clicked) {
+		  event.preventDefault();
+		  event.returnValue = '';
+	  }
+	});
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Add a window event listener to listen when trying to exit the page. This will also mean that the alert is created when submit button is pressed, which is not what we want.
To prevent this we also create an event listener for the submit button that checks if it is pressed, and if it is, then we might leave the page without seeing an alert.

This works now in the add_projects page. Need to find more elegant way to inherit this to all pages... the submit button must be named in order to set an event listener to it.