### PR TITLE
fix the admin link to work in all pages

### DIFF
--- a/pages/templates/base.html
+++ b/pages/templates/base.html
@@ -39,7 +39,7 @@
       </ul>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-            <a href="admin"><img src="static/images/admin-cog.png" style="width:30px;" border="0" alt="admin-link"></a>
+            <a href="{% url 'admin:index' %}"><img src="../static/images/admin-cog.png" style="width:30px;" border="0" alt="admin-link"></a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
With the previous implementation the link and the image related to it crashed when changing page... Now it is fixed, by correcting the path of the image and the admin page link.