### PR TITLE
Do not render results if form hasnt changed

### DIFF
--- a/pages/templates/home.html
+++ b/pages/templates/home.html
@@ -48,7 +48,7 @@ Etsi projekteja tietokannasta
 	</div>
 </div>
 <br>
-
+{% if result %}
 <table id="table_id" class="display responsive" width='100%'>
     <thead>
         <tr>
@@ -85,5 +85,5 @@ $(document).ready( function () {
     $('#table_id').DataTable();
 } );
 </script>
-
+{% endif %}
 {% endblock %}

--- a/pages/views.py
+++ b/pages/views.py
@@ -11,9 +11,10 @@ import pages.scripts.project_search as project_search
 
 def home(request):
 	form = forms.SearchProjectForm(request.GET)
-	if form.is_valid():
+	if form.is_valid() and form.has_changed():
 		result = project_search.search(form)
-	return render(request, 'home.html', {'form':form, 'result':result})
+		return render(request, 'home.html', {'form':form, 'result':result})
+	return render(request, 'home.html', {'form':form})
 
 def post_success(request):
 	return render(request, 'snippets/success.html')


### PR DESCRIPTION
The search project page showed results even when the search was never used or any of the fields was never filled. Now it is fixed