### PR TITLE
add id to forms to make exit warning work

### DIFF
--- a/pages/templates/add_project.html
+++ b/pages/templates/add_project.html
@@ -113,7 +113,7 @@ Lisää projekti
 						{{ form.documentation_path | as_crispy_field }}
 					</div>
 				</div>
-				<button type="submit" class="btn btn-success">Tallenna</button>
+				<button type="submit" id="submit_button" class="btn btn-success">Tallenna</button>
 			</form>
 		</div>
 	</div>


### PR DESCRIPTION
The event listener was listening to events with id that did not exist in the `add_project` forms.